### PR TITLE
ofxConvexHull | namespace-fix - added std::vector namespace

### DIFF
--- a/src/ofxConvexHull.h
+++ b/src/ofxConvexHull.h
@@ -10,6 +10,8 @@
 #include "ofPoint.h"
 #include "ofLog.h"
 
+using std::vector;
+
 class ofxConvexHull
 {
 public:


### PR DESCRIPTION
Fixes **error: ‘vector’ does not name a type.** on gcc  9.3.0